### PR TITLE
Fix build errors with Wayland on Debian 13 (trixie) using Clang 16 (#48)

### DIFF
--- a/Source/wayland/WaylandServer+Cursor.m
+++ b/Source/wayland/WaylandServer+Cursor.m
@@ -38,6 +38,8 @@
 #include <linux/input.h>
 #include "wayland-cursor.h"
 
+extern void wl_cursor_destroy(struct wl_cursor *cursor);
+
 // XXX should this be configurable by the user?
 #define DOUBLECLICK_DELAY 300
 #define DOUBLECLICK_MOVE_THREASHOLD 3

--- a/Source/wayland/WaylandServer+Keyboard.m
+++ b/Source/wayland/WaylandServer+Keyboard.m
@@ -31,6 +31,7 @@
 #include <linux/input.h>
 #include <AppKit/NSText.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
 static void
 keyboard_handle_keymap(void *data, struct wl_keyboard *keyboard,

--- a/Source/wayland/WaylandServer.m
+++ b/Source/wayland/WaylandServer.m
@@ -781,7 +781,7 @@ WaylandServer (SurfaceRoles)
       break;
     case NSPopUpMenuWindowLevel:
       NSDebugLog(@"[%d] NSPopUpMenuWindowLevel", win);
-      [self createPopup:win];
+      [self createPopup:window];
       break;
     case NSScreenSaverWindowLevel:
       NSDebugLog(@"[%d] NSScreenSaverWindowLevel", win);


### PR DESCRIPTION
* Solve an undelcared close function

* Fix xdgshell protocol handling and resolve compile errors

* Fixing build errors in WaylandServer+Cursor

* Revert changes except wl_cursor_destroy to fix build and avoid regressions

* Fix selector warnings and method call type issues

* Use window parameter directly

* Comments removed

* Include NSGraphics to eliminate redundant declaration.

* Remove NSWindow include that was replaced by NSGraphics